### PR TITLE
DOC, FIX: add manual; fix redirect

### DIFF
--- a/mne-python-intro/index.html
+++ b/mne-python-intro/index.html
@@ -2,13 +2,13 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-        <meta http-equiv="refresh" content="1; url=https://mne-tools.github.io/dev/auto_tutorials/intro/plot_introduction.html">
+        <meta http-equiv="refresh" content="1; url=https://mne.tools/dev/auto_tutorials/intro/plot_10_overview.html">
         <script type="text/javascript">
-            window.location.replace("https://mne-tools.github.io/dev/auto_tutorials/intro/plot_introduction.html");
+            window.location.replace("https://mne.tools/dev/auto_tutorials/intro/plot_10_overview.html");
         </script>
         <title>Page Redirection</title>
     </head>
     <body>
-        If you are not redirected automatically, follow <a href="https://mne-tools.github.io/dev/auto_tutorials/intro/plot_introduction.html">this link</a>.
+        If you are not redirected automatically, follow <a href="https://mne.tools/dev/auto_tutorials/intro/plot_10_overview.html">this link</a>.
     </body>
 </html>


### PR DESCRIPTION
- This adds the MNE-C manual PDF (see approval [here](https://github.com/mne-tools/mne-python/pull/6730#issuecomment-528033002)) at the url https://mne.tools/mne-c-manual/MNE-manual-2.7.3.pdf
- Also fixes the old mne-intro-tutorial redirect, as the link has changed (it was giving a 404).