### PR TITLE
WIP: styling tweaks for old version message

### DIFF
--- a/0.11/_static/style.css
+++ b/0.11/_static/style.css
@@ -27,14 +27,14 @@ code {
 .devbar {
     background-color: red;
     color: white;
-    font-weight:bold;
     text-align: center;
     padding: 10px;
     min-width: 910px;
 }
 
 .devbar a {
-    color: #b8bec4;
+    color: #ffffff;
+    font-weight: bold;
 }
 
 #navbar a:hover {


### PR DESCRIPTION
The javascript is working: 

![Screenshot_2020-05-20_14-35-19](https://user-images.githubusercontent.com/1810515/82499784-276ea500-9aa7-11ea-9153-cd2f8cdbfed1.png)

This PR tweaks the legacy CSS so that the devbar looks decent.  This may need to be done for several older versions; if we go this route I'd like to do them all at once in this PR.  An alternative would be to alter the javascript to use inline style defs instead of classes.  That is the approach used in the sklearn version...  it has the advantage of being future-proof against changes in CSS classnames (and not requiring these retroactive CSS changes proposed here). 

@larsoner @hoechenberger WDYT?  Prefer retroactive CSS tweaks, or putting styling code into the JS-written `div` tag?