### PR TITLE
Update versionwarning.js

### DIFF
--- a/versionwarning.js
+++ b/versionwarning.js
@@ -13,14 +13,13 @@
         });
         if (version !== 'stable') {
             // parse version to figure out which website theme classes to use
-            var pre = '<div class="container-fluid alert-danger devbar"><div class="row no-gutters"><div class="col-12 text-center text-dark">';
+            var pre = '<div class="container-fluid alert-danger devbar"><div class="row no-gutters"><div class="col-12 text-center">';
             var post = '</div></div></div>';
-            var anchor = 'class="btn btn-danger alert-link font-weight-bold ml-3 my-3 d-md align-baseline text-white"';
-            if (parseFloat(version) < 0.23) {  // 'stable' or 'dev' → NaN → false (which is what we want)
-                pre = '<div class="d-block devbar alert alert-danger font-weight-normal">';
+            var anchor = 'class="btn btn-danger font-weight-bold ml-3 my-3 align-baseline"';
+            if (parseFloat(version) < 0.23) {  // 'dev' → NaN → false (which is what we want)
+                pre = '<div class="d-block devbar alert alert-danger">';
                 post = '</div>';
-                const style = 'vertical-align: baseline; margin-left: 0.5rem; margin-top: 0.5rem; margin-bottom: 0.5rem; border-style: solid; border-color: white;';
-                anchor = `class="btn btn-danger d-md font-weight-bold" style="${style}"`;
+                anchor = `class="btn btn-danger" style="font-weight: bold; vertical-align: baseline; margin: 0.5rem; border-style: solid; border-color: white;"`;
             }
             // triage message
             var verText = `an <strong>old version (${version})</strong>`;

--- a/versionwarning.js
+++ b/versionwarning.js
@@ -1,29 +1,24 @@
 (function() {
     // adapted 2020-05 from https://scikit-learn.org/versionwarning.js
-    const latestStable = '0.20';
-    const goodPaths = ['stable', 'dev', latestStable];
-    const devbar_style = [
-        'text-align: center',
-        'padding: 5px',
-        'margin-bottom: 5px',
-        'border-radius: 0 0 4px 4px !important',
-        'background-color: #e74c3c',
-        'border-color: #e74c3c',
-        'color: #ffffff',
-        'font-weight: normal'
-    ].join('; ')
-    const showWarning = (msg) => {
-        $('body').prepend(`<div class="d-block devbar alert alert-danger" style="${devbar_style}">${msg}</div>`)
-
-    };
     if (location.hostname === 'mne.tools') {
-        const versionPath = location.pathname.split('/')[1];
-        if (!goodPaths.includes(versionPath)) {
-            const link_style = "color: #ffffff; font-weight: bold"
-            const warning = `This is documentation for an old release of MNE-Python (version ${versionPath}).
-            Try the <a style="${link_style}" href="https://mne.tools">latest stable release</a> (version ${latestStable})
-            or the <a style="${link_style}" href="https://mne.tools/dev">development</a> (unstable) version.`;
-            showWarning(warning)
+        const urlParts = location.pathname.split('/');
+        const version = urlParts[1];
+        var filePath = urlParts.slice(2).join('/');
+        // see if filePath exists in the stable version of the docs
+        $.ajax({
+            type: 'HEAD',
+            url: `https://mne.tools/stable/${filePath}`,
+        }).fail(function() {
+            filePath = '';
+        });
+        if (version !== 'stable') {
+            var verText = `an old version (${version})`;
+            var devLink = `, or the (unstable) <a class="alert-link" href="https://mne.tools/dev/${filePath}">development version</a>`;
+            if (version == 'dev') {
+                verText = 'the <em>unstable development version</em>';
+                devLink = '';
+            }
+            $('body').prepend(`<div class="container-fluid alert-danger devbar"><div class="row no-gutters"><div class="col-12 text-center">This is documentation for ${verText} of MNE-Python. Switch to the <a class="alert-link" href="https://mne.tools/stable/${filePath}">stable version</a>${devLink}.</div></div></div>`);
         }
     }
 })()

--- a/versionwarning.js
+++ b/versionwarning.js
@@ -19,7 +19,7 @@
             if (parseFloat(version) < 0.23) {  // 'dev' → NaN → false (which is what we want)
                 pre = '<div class="d-block devbar alert alert-danger">';
                 post = '</div>';
-                anchor = `class="btn btn-danger" style="font-weight: bold; vertical-align: baseline; margin: 0.5rem; border-style: solid; border-color: white;"`;
+                anchor = 'class="btn btn-danger" style="font-weight: bold; vertical-align: baseline; margin: 0.5rem; border-style: solid; border-color: white;"';
             }
             // triage message
             var verText = `an <strong>old version (${version})</strong>`;

--- a/versionwarning.js
+++ b/versionwarning.js
@@ -17,7 +17,7 @@
             var post = '</div></div></div>';
             var anchor = 'class="alert-link"';
             if (parseFloat(version) < 0.23) {  // 'stable' or 'dev' → NaN → false (which is what we want)
-                pre = '<div class="d-block devbar alert alert-danger" style="font-weight: normal;"></div>';
+                pre = '<div class="d-block devbar alert alert-danger" style="font-weight: normal;">';
                 post = '</div>';
                 anchor = 'style="font-weight: bold; color: #fff;"';
             }

--- a/versionwarning.js
+++ b/versionwarning.js
@@ -13,22 +13,21 @@
         });
         if (version !== 'stable') {
             // parse version to figure out which website theme classes to use
-            var pre = '<div class="container-fluid alert-danger devbar"><div class="row no-gutters"><div class="col-12 text-center">';
+            var pre = '<div class="container-fluid alert-danger devbar"><div class="row no-gutters"><div class="col-12 text-center text-dark">';
             var post = '</div></div></div>';
-            var anchor = 'class="btn btn-danger alert-link"';
+            var anchor = 'class="btn btn-danger alert-link font-weight-bold ml-3 my-3 d-md align-baseline text-white"';
             if (parseFloat(version) < 0.23) {  // 'stable' or 'dev' → NaN → false (which is what we want)
-                pre = '<div class="d-block devbar alert alert-danger" style="font-weight: normal;">';
+                pre = '<div class="d-block devbar alert alert-danger font-weight-normal">';
                 post = '</div>';
-                anchor = 'class="btn btn-danger" style="font-weight: bold; color: #fff;"';
+                const style = 'vertical-align: baseline; margin-left: 0.5rem; margin-top: 0.5rem; margin-bottom: 0.5rem; border-style: solid; border-color: white;';
+                anchor = `class="btn btn-danger d-md font-weight-bold" style="${style}"`;
             }
             // triage message
-            var verText = `an old version (${version})`;
-            var devLink = `<a ${anchor} href="https://mne.tools/dev/${filePath}">Switch to development version</a>`;
+            var verText = `an <strong>old version (${version})</strong>`;
             if (version == 'dev') {
-                verText = 'the <em>unstable development version</em>';
-                devLink = '';
+                verText = 'the <strong>unstable development version</strong>';
             }
-            $('body').prepend(`${pre}This is documentation for ${verText} of MNE-Python. <a ${anchor} href="https://mne.tools/stable/${filePath}">Switch to stable version</a>${devLink}${post}`);
+            $('body').prepend(`${pre}This is documentation for ${verText} of MNE-Python. <a ${anchor} href="https://mne.tools/stable/${filePath}">Switch to stable version</a>${post}`);
         }
     }
 })()

--- a/versionwarning.js
+++ b/versionwarning.js
@@ -15,20 +15,20 @@
             // parse version to figure out which website theme classes to use
             var pre = '<div class="container-fluid alert-danger devbar"><div class="row no-gutters"><div class="col-12 text-center">';
             var post = '</div></div></div>';
-            var anchor = 'class="alert-link"';
+            var anchor = 'class="btn btn-danger alert-link"';
             if (parseFloat(version) < 0.23) {  // 'stable' or 'dev' → NaN → false (which is what we want)
                 pre = '<div class="d-block devbar alert alert-danger" style="font-weight: normal;">';
                 post = '</div>';
-                anchor = 'style="font-weight: bold; color: #fff;"';
+                anchor = 'class="btn btn-danger" style="font-weight: bold; color: #fff;"';
             }
             // triage message
             var verText = `an old version (${version})`;
-            var devLink = `, or the (unstable) <a ${anchor} href="https://mne.tools/dev/${filePath}">development version</a>`;
+            var devLink = `<a ${anchor} href="https://mne.tools/dev/${filePath}">Switch to development version</a>`;
             if (version == 'dev') {
                 verText = 'the <em>unstable development version</em>';
                 devLink = '';
             }
-            $('body').prepend(`${pre}This is documentation for ${verText} of MNE-Python. Switch to the <a ${anchor} href="https://mne.tools/stable/${filePath}">stable version</a>${devLink}.${post}`);
+            $('body').prepend(`${pre}This is documentation for ${verText} of MNE-Python. <a ${anchor} href="https://mne.tools/stable/${filePath}">Switch to stable version</a>${devLink}${post}`);
         }
     }
 })()

--- a/versionwarning.js
+++ b/versionwarning.js
@@ -3,8 +3,8 @@
     if (location.hostname === 'mne.tools') {
         const urlParts = location.pathname.split('/');
         const version = urlParts[1];
-        var filePath = urlParts.slice(2).join('/');
         // see if filePath exists in the stable version of the docs
+        var filePath = urlParts.slice(2).join('/');
         $.ajax({
             type: 'HEAD',
             url: `https://mne.tools/stable/${filePath}`,
@@ -12,13 +12,23 @@
             filePath = '';
         });
         if (version !== 'stable') {
+            // parse version to figure out which website theme classes to use
+            var pre = '<div class="container-fluid alert-danger devbar"><div class="row no-gutters"><div class="col-12 text-center">';
+            var post = '</div></div></div>';
+            var anchor = 'class="alert-link"';
+            if (parseFloat(version) < 0.23) {  // 'stable' or 'dev' → NaN → false (which is what we want)
+                pre = '<div class="d-block devbar alert alert-danger" style="font-weight: normal;"></div>';
+                post = '</div>';
+                anchor = 'style="font-weight: bold; color: #fff;"';
+            }
+            // triage message
             var verText = `an old version (${version})`;
-            var devLink = `, or the (unstable) <a class="alert-link" href="https://mne.tools/dev/${filePath}">development version</a>`;
+            var devLink = `, or the (unstable) <a ${anchor} href="https://mne.tools/dev/${filePath}">development version</a>`;
             if (version == 'dev') {
                 verText = 'the <em>unstable development version</em>';
                 devLink = '';
             }
-            $('body').prepend(`<div class="container-fluid alert-danger devbar"><div class="row no-gutters"><div class="col-12 text-center">This is documentation for ${verText} of MNE-Python. Switch to the <a class="alert-link" href="https://mne.tools/stable/${filePath}">stable version</a>${devLink}.</div></div></div>`);
+            $('body').prepend(`${pre}This is documentation for ${verText} of MNE-Python. Switch to the <a ${anchor} href="https://mne.tools/stable/${filePath}">stable version</a>${devLink}.${post}`);
         }
     }
 })()


### PR DESCRIPTION
- lets the `versionwarning.js` script also generate the "unstable" warning bar on the development version
- links to the corresponding page (if it exists) in the current stable (or dev) docs, instead of always linking to the homepage.

drawbacks:
- not thoroughly tested yet
- the bootstrap 4 classes aren't going to exist on old versions of the docs, so the styling will be messed up.

I'm opening this mostly for discussion purposes, so y'all can see what this solution would look like.  I think the actual right way to fix this is:

1. minimally update `versionwarning.js` to do the linking to the corresponding page (but keep the old `devbar_style` stuff)
2. put a similar javascript into the main codebase (i.e., not in the root of `mne.tools`) that uses BS4 classes instead of hardcoded styles
3. in current main, remove the part of `doc/_templates/layout.html` that inserts the devbar, and update it to load a new version of this `versionwarning` function that lives in `doc/_static/` somewhere.

That way, old docs use the old script here (which has appropriate styling) and new docs will use the new function (which has appropriate classes for the new theme), and will continue to work well once they become no longer the current `dev` version.