### PR TITLE
wait for ajax result before writing to document

### DIFF
--- a/versionwarning.js
+++ b/versionwarning.js
@@ -8,25 +8,28 @@
         $.ajax({
             type: 'HEAD',
             url: `https://mne.tools/stable/${filePath}`,
-        }).fail(function() {
-            filePath = '';
+            error: function() {
+                filePath = '';
+            },
+            complete: function() {
+                if (version !== 'stable') {
+                    // parse version to figure out which website theme classes to use
+                    var pre = '<div class="container-fluid alert-danger devbar"><div class="row no-gutters"><div class="col-12 text-center">';
+                    var post = '</div></div></div>';
+                    var anchor = 'class="btn btn-danger font-weight-bold ml-3 my-3 align-baseline"';
+                    if (parseFloat(version) < 0.23) {  // 'dev' → NaN → false (which is what we want)
+                        pre = '<div class="d-block devbar alert alert-danger">';
+                        post = '</div>';
+                        anchor = 'class="btn btn-danger" style="font-weight: bold; vertical-align: baseline; margin: 0.5rem; border-style: solid; border-color: white;"';
+                    }
+                    // triage message
+                    var verText = `an <strong>old version (${version})</strong>`;
+                    if (version == 'dev') {
+                        verText = 'the <strong>unstable development version</strong>';
+                    }
+                    $('body').prepend(`${pre}This is documentation for ${verText} of MNE-Python. <a ${anchor} href="https://mne.tools/stable/${filePath}">Switch to stable version</a>${post}`);
+                }
+            }
         });
-        if (version !== 'stable') {
-            // parse version to figure out which website theme classes to use
-            var pre = '<div class="container-fluid alert-danger devbar"><div class="row no-gutters"><div class="col-12 text-center">';
-            var post = '</div></div></div>';
-            var anchor = 'class="btn btn-danger font-weight-bold ml-3 my-3 align-baseline"';
-            if (parseFloat(version) < 0.23) {  // 'dev' → NaN → false (which is what we want)
-                pre = '<div class="d-block devbar alert alert-danger">';
-                post = '</div>';
-                anchor = 'class="btn btn-danger" style="font-weight: bold; vertical-align: baseline; margin: 0.5rem; border-style: solid; border-color: white;"';
-            }
-            // triage message
-            var verText = `an <strong>old version (${version})</strong>`;
-            if (version == 'dev') {
-                verText = 'the <strong>unstable development version</strong>';
-            }
-            $('body').prepend(`${pre}This is documentation for ${verText} of MNE-Python. <a ${anchor} href="https://mne.tools/stable/${filePath}">Switch to stable version</a>${post}`);
-        }
     }
 })()


### PR DESCRIPTION
This just puts everything after the `ajax` call into its `success` function, so that the ajax `error` function is guaranteed to have happened *before* the devbar warning gets written.