### PR TITLE
purge jquery; automate checking against stable

### DIFF
--- a/versionwarning.js
+++ b/versionwarning.js
@@ -3,21 +3,30 @@
     if (location.hostname === 'mne.tools') {
         const urlParts = location.pathname.split('/');
         const version = urlParts[1];
+        const releases = Array.from(
+            document.querySelector('.version-switcher__menu')
+        );
+        const latest_stable = parseFloat(
+            releases.filter(
+                ver => ver.getAttribute('data-version') == 'stable'
+            )[0].getAttribute('data-version-name').split(' ')[0]
+        )
         // see if filePath exists in the stable version of the docs
         var filePath = urlParts.slice(2).join('/');
-        $.ajax({
-            type: 'HEAD',
-            url: `https://mne.tools/stable/${filePath}`,
-            error: function() {
-                filePath = '';
-            },
-            complete: function() {
+
+        fetch(`https://mne.tools/stable/${filePath}`, { method: "HEAD" })
+            .then((response) => {
+                if (!response.ok) {
+                    filePath = '';
+                }
+            })
+            .then(() => {
                 if (version !== 'stable') {
                     // parse version to figure out which website theme classes to use
-                    var pre = '<div class="container-fluid alert-danger devbar"><div class="row no-gutters"><div class="col-12 text-center">';
+                    var pre = '<div class="bd-header-announcement container-fluid"><div class="bd-header-announcement__content"><div class="sidebar-message">';
                     var post = '</div></div></div>';
-                    var anchor = 'class="btn btn-danger font-weight-bold ml-3 my-3 align-baseline"';
-                    if (parseFloat(version) < 0.23) {  // 'dev' → NaN → false (which is what we want)
+                    var anchor = 'class="sd-btn sd-btn-danger sd-shadow-sm sd-text-wrap font-weight-bold ms-3 my-3 align-baseline"';
+                    if (parseFloat(version) < latest_stable) {  // 'dev' → NaN → false (which is what we want)
                         pre = '<div class="d-block devbar alert alert-danger">';
                         post = '</div>';
                         anchor = 'class="btn btn-danger" style="font-weight: bold; vertical-align: baseline; margin: 0.5rem; border-style: solid; border-color: white;"';
@@ -27,9 +36,8 @@
                     if (version == 'dev') {
                         verText = 'the <strong>unstable development version</strong>';
                     }
-                    $('body').prepend(`${pre}This is documentation for ${verText} of MNE-Python. <a ${anchor} href="https://mne.tools/stable/${filePath}">Switch to stable version</a>${post}`);
+                    document.querySelector('body').prepend(`${pre}This is documentation for ${verText} of MNE-Python. <a ${anchor} href="https://mne.tools/stable/${filePath}">Switch to stable version</a>${post}`);
                 }
-            }
-        });
+            })
     }
 })()


### PR DESCRIPTION
With update to sphinx 6 and pydata-sphinx-theme 0.13 we will no longer have jquery. This purges it from our versionwarning script, and also automates the process of figuring out the version number of `stable` so we don't have to update this script with every release (which we haven't been doing, it was checking against 0.23)